### PR TITLE
fix: interceptor bug on 401 Unauthorized response

### DIFF
--- a/src/components/ResultLayout/index.tsx
+++ b/src/components/ResultLayout/index.tsx
@@ -1,14 +1,28 @@
 import { Button, Stack, Typography } from '@mui/material';
-import { Link } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { useAuth } from 'src/hooks/useAuth';
 
 type ResultPageProps = {
   image: string;
   title: string;
   body: string;
   buttonText: string;
+  type?: "default" | "unauthorized"
 };
 
-export const ResultLayout = ({ image, title, body, buttonText }: ResultPageProps) => {
+export const ResultLayout = ({ image, title, body, buttonText, type = "default" }: ResultPageProps) => {
+
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    if(type === 'unauthorized') {
+      useAuth.getState().logout();
+      navigate({to: '/login'});
+    } else {
+      navigate({to: '/'});
+    }
+  };
+
   return (
     <Stack justifyContent="center" py={4}>
       <Stack alignItems="center" gap={4} maxWidth={'sm'} alignSelf="center">
@@ -24,19 +38,17 @@ export const ResultLayout = ({ image, title, body, buttonText }: ResultPageProps
           </Stack>
         </Stack>
         <Stack pr={8} pl={8} sx={{ width: '100%', height: '100%' }}>
-          <Link to="/">
-            <Button
-              type="button"
-              variant="contained"
-              style={{
-                width: '100%',
-                height: '100%',
-                minHeight: 45,
-              }}
-            >
-              {buttonText}
-            </Button>
-          </Link>
+          <Button onClick={handleClick}
+            type="button"
+            variant="contained"
+            style={{
+              width: '100%',
+              height: '100%',
+              minHeight: 45,
+            }}
+          >
+            {buttonText}
+          </Button>
         </Stack>
       </Stack>
     </Stack>

--- a/src/pages/KOPage/index.tsx
+++ b/src/pages/KOPage/index.tsx
@@ -1,16 +1,19 @@
 import { useTranslation } from 'react-i18next';
 import ko from '../../assets/images/ko.svg';
 import { ResultLayout } from 'src/components/ResultLayout';
+import useMessageStore from 'src/stores/message.store';
 
 export default function KOPage() {
   const { t } = useTranslation();
+  const { messageStatus } = useMessageStore() as { messageStatus: "default" | "unauthorized" | undefined };
 
   return (
     <ResultLayout
       image={ko}
-      title={t('KO.title')}
-      body={t('KO.body')}
-      buttonText={t('KO.button')}
+      title={t(`KO.${messageStatus}.title`)}
+      body={t(`KO.${messageStatus}.body`)}
+      buttonText={t(`KO.${messageStatus}.button`)}
+      type={messageStatus}
     />
   );
 }

--- a/src/stores/message.store.ts
+++ b/src/stores/message.store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+export type MessageStore = {
+  messageStatus: "default" | "unauthorized";
+  setMessageStatus: (value: "default" | "unauthorized") => void;
+}
+
+const useMessageStore = create<MessageStore>((set) => ({
+  messageStatus: 'default',
+  setMessageStatus: (value: "default" | "unauthorized") => set({ messageStatus: value }),
+}));
+
+export default useMessageStore;

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -85,9 +85,16 @@
 		}
 	},
 	"KO": {
-		"title": "Qualcosa è andato storto",
-		"body": "Il codice fiscale indicato non è attivo",
-		"button": "Torna alla richiesta di pagamento"
+		"default": {
+			"title": "Qualcosa è andato storto",
+			"body": "Il codice fiscale indicato non è attivo",
+			"button": "Torna alla richiesta di pagamento"
+		},
+		"unauthorized": {
+			"title": "Qualcosa è andato storto",
+			"body": "La tua sessione è scaduta. Accedi nuovamente per continuare.",
+			"button": "Torna alla login"
+		}
 	},
 	"OK": {
 		"title": "La richiesta è stata inviata con successo!",

--- a/src/utils/auth.utils.ts
+++ b/src/utils/auth.utils.ts
@@ -1,0 +1,9 @@
+import { router } from "src/main";
+import useMessageStore from "src/stores/message.store";
+
+export function invalidateSession() {
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+  useMessageStore.getState().setMessageStatus('unauthorized');
+  return router.navigate({to: '/ko'});
+}


### PR DESCRIPTION
#### Description
Fix bug on interceptor file. Management of state 401, with call for refresh_token and management of its error. Added a new error message with redirect button to login

#### List of Changes
interceptors.ts -> Added check for 401 status, call management refresh_token, and error management
ResultLayout/index.tsx -> Added new message with redirect button to login
message.store.ts -> Added dynamic message result
translations/it/translations.json -> Added new labels for messages
src/utils/auth.utils.ts -> Added auth utils for redirect to error page

