### PR TITLE
feat: add cancel RTP functionality

### DIFF
--- a/src/api/useCancelRtp.ts
+++ b/src/api/useCancelRtp.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+import { client } from "./client";
+import { v4 as uuidv4 } from "uuid";
+import { CONTENT_TYPE } from "src/models/Requests";
+
+export const useCancelRtp = () => {
+  return useMutation({
+    mutationKey: ["cancelRtp"],
+    mutationFn: (rtpId: string) =>
+      client.api.rtps.cancelRtp(rtpId, {
+        headers: {
+          version: "v1",
+          requestId: uuidv4(),
+          "content-type": CONTENT_TYPE.JSON,
+        },
+      }),
+  });
+};

--- a/src/api/useRefreshToken.test.ts
+++ b/src/api/useRefreshToken.test.ts
@@ -1,15 +1,10 @@
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
-import { useMutation } from '@tanstack/react-query';
-import { useRefreshToken } from './useRefreshToken';
-import { client } from './client';
+import { describe, it, expect, vi } from 'vitest';
+import { client } from './client'; // importa il client da mockare
 import { RefreshGrantType } from 'generated/auth/data-contracts';
+import { ACCEPT_FORMAT, CONTENT_TYPE } from 'src/models/Requests';
+import { refreshToken } from './useRefreshToken';
+import { Mock } from 'vitest';
 
-// Mock @tanstack/react-query
-vi.mock('@tanstack/react-query', () => ({
-  useMutation: vi.fn(),
-}));
-
-// Mock client
 vi.mock('./client', () => ({
   client: {
     auth: {
@@ -18,72 +13,40 @@ vi.mock('./client', () => ({
   },
 }));
 
-describe('useRefreshToken', () => {
-  const mutateMock = vi.fn();
-  const mutationResult = { mutate: mutateMock };
+describe('refreshToken', () => {
+  it('should call getAccessTokens with correct parameters and return data', async () => {
+    const refreshTokenMock = 'refresh-token';
+    const responseDataMock = { access_token: 'new-access-token' };
 
-  beforeEach(() => {
-    // Reset mocks before each test
-    vi.clearAllMocks();
-
-    // Mock useMutation to return a controlled result
-    (useMutation as Mock).mockReturnValue(mutationResult);
-  });
-
-  it('should call useMutation with the correct mutationKey and mutationFn', () => {
-    useRefreshToken();
-
-    expect(useMutation).toHaveBeenCalledWith({
-      mutationKey: ['getToken'],
-      mutationFn: expect.any(Function),
+    (client.auth.getAccessTokens as Mock).mockResolvedValueOnce({
+      data: responseDataMock,
     });
-  });
 
-  it('should call client.auth.getAccessTokens with the correct parameters', async () => {
-    const refreshToken = 'test-refresh-token';
-    const expectedData = {
-      refresh_token: refreshToken,
-      grant_type: RefreshGrantType.RefreshToken,
-      client_id: '1ec1f3f4-411b-4dc3-ad1c-68196af7e90c',
-    };
-    const expectedHeaders = {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        Accept: 'application/json;charset=UTF-8',
+    const result = await refreshToken(refreshTokenMock);
+
+    expect(client.auth.getAccessTokens).toHaveBeenCalledWith(
+      {
+        refresh_token: refreshTokenMock,
+        grant_type: RefreshGrantType.RefreshToken,
+        client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
       },
-    };
+      {
+        headers: {
+          "Content-Type": CONTENT_TYPE.URL_ENCODED,
+          Accept: ACCEPT_FORMAT.JSON,
+        },
+      }
+    );
 
-    useRefreshToken();
-
-    // Get the mutation function passed to useMutation
-    const mutationFn = (useMutation as Mock).mock.calls[0][0].mutationFn;
-
-    // Call the mutation function with test data
-    await mutationFn({ refresh_token: refreshToken });
-
-    // Verify that client.auth.getAccessTokens was called with the correct parameters
-    expect(client.auth.getAccessTokens).toHaveBeenCalledWith(expectedData, expectedHeaders);
+    expect(result).toEqual(responseDataMock);
   });
 
-  it('should return the result of useMutation', () => {
-    const result = useRefreshToken();
+  it('should throw an error if getAccessTokens fails', async () => {
+    const refreshTokenMock = 'mock-refresh-token';
+    const errorMessage = 'API Error';
 
-    expect(result).toBe(mutationResult);
-  });
+    (client.auth.getAccessTokens as Mock).mockRejectedValue(new Error(errorMessage));
 
-  it('should handle errors from client.auth.getAccessTokens', async () => {
-    const refreshToken = 'test-refresh-token';
-    const error = new Error('API error');
-
-    // Mock client.auth.getAccessTokens to throw an error
-    (client.auth.getAccessTokens as Mock).mockRejectedValueOnce(error);
-
-    useRefreshToken();
-
-    // Get the mutation function passed to useMutation
-    const mutationFn = (useMutation as Mock).mock.calls[0][0].mutationFn;
-
-    // Call the mutation function and expect it to throw
-    await expect(mutationFn({ refresh_token: refreshToken })).rejects.toThrow(error);
+    await expect(refreshToken(refreshTokenMock)).rejects.toThrow(errorMessage);
   });
 });

--- a/src/api/useRefreshToken.ts
+++ b/src/api/useRefreshToken.ts
@@ -1,29 +1,22 @@
-import { useMutation } from "@tanstack/react-query";
 import { client } from "./client";
 import {
-  RefreshAccessToken,
   RefreshGrantType,
 } from "generated/auth/data-contracts";
 import { ACCEPT_FORMAT, CONTENT_TYPE } from "src/models/Requests";
 
-export const useRefreshToken = () => {
-  const auth = useMutation({
-    mutationKey: ["getToken"],
-    mutationFn: async (data: Pick<RefreshAccessToken, "refresh_token">) =>
-      await client.auth.getAccessTokens(
-        {
-          ...data,
-          grant_type: RefreshGrantType.RefreshToken,
-          client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
-        },
-        {
-          headers: {
-            "Content-Type": CONTENT_TYPE.URL_ENCODED,
-            Accept: ACCEPT_FORMAT.JSON,
-          },
-        },
-      ),
-  });
-
-  return auth;
+export const refreshToken = async (refreshToken: string) => {
+  const response = await client.auth.getAccessTokens(
+    {
+      refresh_token: refreshToken,
+      grant_type: RefreshGrantType.RefreshToken,
+      client_id: import.meta.env.VITE_AUTH_CLIENT_ID,
+    },
+    {
+      headers: {
+        "Content-Type": CONTENT_TYPE.URL_ENCODED,
+        Accept: ACCEPT_FORMAT.JSON,
+      },
+    }
+  );
+  return response.data;
 };

--- a/src/components/Dialogs/DialogRtpDelete/index.tsx
+++ b/src/components/Dialogs/DialogRtpDelete/index.tsx
@@ -1,6 +1,8 @@
-import { Button, Stack, Typography } from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import { Alert, Button, Stack, Typography } from "@mui/material";
 import { useNavigate } from "@tanstack/react-router";
 import { Trans, useTranslation } from "react-i18next";
+import { useCancelRtp } from "src/api/useCancelRtp";
 import { useDialog } from "src/stores/dialog.store";
 import useMessageStore from "src/stores/message.store";
 
@@ -14,12 +16,16 @@ export default function DialogRtpDelete({rtpId}: DialogRtpDeleteProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { setMessageStatus } = useMessageStore();
+  const { mutate, isPending, isError } = useCancelRtp();
 
   const handleRtpDeletion = () => {
-    console.log("DELETE ", rtpId);
-    setMessageStatus("deleted");
-    closeDialog();
-    navigate({to: "/ok"});
+    mutate(rtpId, {
+      onSuccess: () => {
+        setMessageStatus("deleted");
+        closeDialog();
+        navigate({to: "/ok"});
+      },
+    });
   };
 
   return (
@@ -28,8 +34,19 @@ export default function DialogRtpDelete({rtpId}: DialogRtpDeleteProps) {
         <Trans i18nKey={"Dialogs.delete.description"} />
       </Typography>
 
+      {isError &&
+        <Alert
+          variant="outlined"
+          severity="error"
+          sx={{ flexGrow: 1, height: "100%", mb: "32px" }}
+        >
+          {t("CancelRtp.error")}
+        </Alert>
+      }
+
       <Stack direction={{ xs: "column", sm: "row" }} justifyContent={"end"} gap={2}>
         <Button
+          disabled={isPending}
           type="button"
           variant="outlined"
           color="primary"
@@ -45,7 +62,8 @@ export default function DialogRtpDelete({rtpId}: DialogRtpDeleteProps) {
           <Trans i18nKey={"Dialogs.delete.declineAction"} />
         </Button>
 
-        <Button
+        <LoadingButton
+          loading={isPending}
           type="button"
           variant="contained"
           color="primary"
@@ -59,7 +77,7 @@ export default function DialogRtpDelete({rtpId}: DialogRtpDeleteProps) {
           aria-label={t("Dialogs.delete.confirmAction")}
         >
           <Trans i18nKey={"Dialogs.delete.confirmAction"} />
-        </Button>
+        </LoadingButton>
       </Stack>
     </>
   );

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import Alert from "@mui/material/Alert";
 import { useAuth } from "src/hooks/useAuth";
 import { userEmail } from "src/utils/userEmail.utils";
+import { useEffect } from "react";
 
 type UserCredentials = Pick<GetAccessTokenByPassword, "username" | "password">;
 
@@ -36,9 +37,11 @@ export const Login = () => {
     });
   };
 
-  if (auth.isAuthenticated) {
-    navigate({ to: "/" });
-  }
+  useEffect(() => {
+    if (auth.isAuthenticated) {
+      navigate({ to: "/" });
+    }
+  }, [auth.isAuthenticated, navigate]);
 
   return (
     <Stack justifyContent="center" alignItems="center" py={4} gap={4}>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -92,6 +92,9 @@
 			}
 		}
 	},
+	"CancelRtp": {
+		"error": "Errore durante la cancellazione della richiesta di pagamento"
+	},
 	"KO": {
 		"default": {
 			"title": "Qualcosa è andato storto",

--- a/src/utils/auth.utils.ts
+++ b/src/utils/auth.utils.ts
@@ -1,10 +1,15 @@
 import { router } from "src/main";
+import { useDialogStore } from "src/stores/dialog.store";
 import useMessageStore from "src/stores/message.store";
 
 export function invalidateSession() {
   localStorage.removeItem('accessToken');
   localStorage.removeItem('refreshToken');
   localStorage.removeItem('user');
+  const dialogState = useDialogStore.getState().dialog;
+  if(dialogState) {
+    useDialogStore.getState().closeDialog();
+  }
   useMessageStore.getState().setMessageStatus('unauthorized');
-  return router.navigate({to: '/ko'});
+  return router.navigate({ to: '/ko' });
 }

--- a/src/utils/utilsTest/auth.test.ts
+++ b/src/utils/utilsTest/auth.test.ts
@@ -2,6 +2,7 @@ import { router } from "src/main";
 import useMessageStore from "src/stores/message.store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { invalidateSession } from "../auth.utils";
+import { useDialogStore } from "src/stores/dialog.store";
 
 vi.mock("src/main", () => ({
   router: {
@@ -19,6 +20,15 @@ vi.mock("src/stores/message.store", () => {
   };
 });
 
+vi.mock("src/stores/dialog.store", () => ({
+  useDialogStore: {
+    getState: vi.fn().mockReturnValue({
+      dialog: true,
+      closeDialog: vi.fn(),
+    }),
+  },
+}));
+
 describe("invalidateSession", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -27,6 +37,7 @@ describe("invalidateSession", () => {
 
   it("should remove tokens and update the message status", () => {
     const setMessageStatusMock = useMessageStore.getState().setMessageStatus;
+    const closeDialogMock = useDialogStore.getState().closeDialog;
 
     invalidateSession();
 
@@ -35,7 +46,7 @@ describe("invalidateSession", () => {
     expect(localStorage.getItem('user')).toBeNull();
 
     expect(setMessageStatusMock).toHaveBeenCalledWith('unauthorized');
-
+    expect(closeDialogMock).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalledWith({ to: '/ko' });
   });
 });


### PR DESCRIPTION
#### Description
Added cancel RTP functionality

#### List of Changes
src/api/interceptors.ts -> Improved error handling
src/api/useCancelRtp.ts -> Added hook for cancel
src/api/useRefreshToken.ts -> Hook transformation in function for a correct management inside the interceptor
src/api/useRefreshToken.test.ts -> Updated tests for the new function
src/components/Dialogs/DialogRtpDelete/index.tsx -> Adding cancel action
src/pages/Login/index.tsx -> Fix for warning
src/utils/auth.utils.ts -> Updated function for cancel management
src/utils/utilsTest/auth.test.ts ->  Updated tests



