### PR TITLE
feat: SRTP-1947 add versioning support to RTP submission and update button labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist
 build
 
 /generated
+
+.idea

--- a/src/api/useCancelRtp.ts
+++ b/src/api/useCancelRtp.ts
@@ -8,17 +8,18 @@ export type { CancelReason };
 export type CancelRtpParams = {
   rtpId: string;
   reason: CancelReason;
+  version?: string;
 };
 
 export const useCancelRtp = () => {
   return useMutation({
     mutationKey: ["cancelRtp"],
-    mutationFn: ({ rtpId, reason }: CancelRtpParams) =>
+    mutationFn: ({ rtpId, reason, version = "v1" }: CancelRtpParams) =>
       client.api.rtps.cancelRtp(
         { resourceId: rtpId, reason },
         {
           headers: {
-            version: "v1",
+            version,
             requestId: uuidv4(),
           },
         }

--- a/src/api/useRtps.ts
+++ b/src/api/useRtps.ts
@@ -8,10 +8,10 @@ import { CONTENT_TYPE } from "src/models/Requests";
 export const useRtps = () => {
   const rtp = useMutation({
     mutationKey: ["createRtp"],
-    mutationFn: async (data: CreateRtp) =>
+    mutationFn: async ({ data, version = "v1" }: { data: CreateRtp; version?: string }) =>
       await client.api.rtps.createRtp(data, {
         headers: {
-          version: "v1",
+          version,
           requestId: uuidv4(),
           "content-type": CONTENT_TYPE.JSON,
         },

--- a/src/components/Dialogs/DialogRtpDelete/index.tsx
+++ b/src/components/Dialogs/DialogRtpDelete/index.tsx
@@ -10,9 +10,10 @@ import useMessageStore from "src/stores/message.store";
 export type DialogRtpDeleteProps = {
     rtpId: string;
     reason: CancelReason;
+    version: string;
 }
 
-export default function DialogRtpDelete({rtpId, reason}: DialogRtpDeleteProps) {
+export default function DialogRtpDelete({rtpId, reason, version}: DialogRtpDeleteProps) {
 
   const { closeDialog } = useDialog();
   const { t } = useTranslation();
@@ -21,7 +22,7 @@ export default function DialogRtpDelete({rtpId, reason}: DialogRtpDeleteProps) {
   const { mutate, isPending, isError } = useCancelRtp();
 
   const handleRtpDeletion = () => {
-    mutate({ rtpId, reason }, {
+    mutate({ rtpId, reason, version }, {
       onSuccess: () => {
         setMessageStatus("deleted");
         closeDialog();

--- a/src/components/ResultLayout/index.tsx
+++ b/src/components/ResultLayout/index.tsx
@@ -12,18 +12,20 @@ type ResultPageProps = {
   title: string;
   body: string;
   buttonText: string;
-  cancelModtButtonText?: string;
-  cancelPaidButtonText?: string;
+  cancelModtButtonTextV3?: string;
+  cancelModtButtonTextV4?: string;
+  cancelPaidButtonTextV3?: string;
+  cancelPaidButtonTextV4?: string;
   rtpCode?: string;
   type?: MessageStatus
 };
 
-export const ResultLayout = ({ image, title, body, buttonText, cancelModtButtonText, cancelPaidButtonText, rtpCode, type = "default" }: ResultPageProps) => {
+export const ResultLayout = ({ image, title, body, buttonText, cancelModtButtonTextV3, cancelModtButtonTextV4, cancelPaidButtonTextV3, cancelPaidButtonTextV4, rtpCode, type = "default" }: ResultPageProps) => {
 
   const navigate = useNavigate();
   const { openDialog } = useDialog();
 
-  const hasCancelButtons = (cancelModtButtonText || cancelPaidButtonText) && rtpCode;
+  const hasCancelButtons = (cancelModtButtonTextV3 || cancelModtButtonTextV4 || cancelPaidButtonTextV3 || cancelPaidButtonTextV4) && rtpCode;
 
   const handleClick = () => {
     if(type === 'unauthorized') {
@@ -65,31 +67,59 @@ export const ResultLayout = ({ image, title, body, buttonText, cancelModtButtonT
           </Button>
 
           {hasCancelButtons && (
-            <Stack direction={{ xs: "column", sm: "row" }} gap={2}>
-              {cancelModtButtonText && (
-                <Button
-                  type="button"
-                  variant="outlined"
-                  color="error"
-                  fullWidth
-                  style={{ minHeight: 45 }}
-                  onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.MODT))}
-                >
-                  {cancelModtButtonText}
-                </Button>
-              )}
-              {cancelPaidButtonText && (
-                <Button
-                  type="button"
-                  variant="outlined"
-                  color="error"
-                  fullWidth
-                  style={{ minHeight: 45 }}
-                  onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.PAID))}
-                >
-                  {cancelPaidButtonText}
-                </Button>
-              )}
+            <Stack direction="column" gap={2}>
+              <Stack direction={{ xs: "column", sm: "row" }} gap={2}>
+                {cancelModtButtonTextV3 && (
+                  <Button
+                    type="button"
+                    variant="outlined"
+                    color="error"
+                    fullWidth
+                    style={{ minHeight: 45 }}
+                    onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.MODT, "v1"))}
+                  >
+                    {cancelModtButtonTextV3}
+                  </Button>
+                )}
+                {cancelModtButtonTextV4 && (
+                  <Button
+                    type="button"
+                    variant="contained"
+                    color="error"
+                    fullWidth
+                    style={{ minHeight: 45 }}
+                    onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.MODT, "v2"))}
+                  >
+                    {cancelModtButtonTextV4}
+                  </Button>
+                )}
+              </Stack>
+              <Stack direction={{ xs: "column", sm: "row" }} gap={2}>
+                {cancelPaidButtonTextV3 && (
+                  <Button
+                    type="button"
+                    variant="outlined"
+                    color="error"
+                    fullWidth
+                    style={{ minHeight: 45 }}
+                    onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.PAID, "v1"))}
+                  >
+                    {cancelPaidButtonTextV3}
+                  </Button>
+                )}
+                {cancelPaidButtonTextV4 && (
+                  <Button
+                    type="button"
+                    variant="contained"
+                    color="error"
+                    fullWidth
+                    style={{ minHeight: 45 }}
+                    onClick={() => openDialog(getDialogData(DialogType.DELETE, rtpCode, CancelReason.PAID, "v2"))}
+                  >
+                    {cancelPaidButtonTextV4}
+                  </Button>
+                )}
+              </Stack>
             </Stack>
           )}
         </Stack>

--- a/src/pages/ConfimedPage.tsx
+++ b/src/pages/ConfimedPage.tsx
@@ -14,8 +14,10 @@ export default function ConfirmedPage() {
       title={t(`OK.rtpParams.title`) || ''}
       body={t(`OK.rtpParams.body`)}
       buttonText={t(`OK.rtpParams.button`)}
-      cancelModtButtonText={t(`OK.rtpParams.cancelModtButton`)}
-      cancelPaidButtonText={t(`OK.rtpParams.cancelPaidButton`)}
+      cancelModtButtonTextV3={t(`OK.rtpParams.cancelModtButtonV3`)}
+      cancelModtButtonTextV4={t(`OK.rtpParams.cancelModtButtonV4`)}
+      cancelPaidButtonTextV3={t(`OK.rtpParams.cancelPaidButtonV3`)}
+      cancelPaidButtonTextV4={t(`OK.rtpParams.cancelPaidButtonV4`)}
       rtpCode={id}
       type={"rtpParams"}
     />

--- a/src/pages/CreateRtpPage/index.tsx
+++ b/src/pages/CreateRtpPage/index.tsx
@@ -24,7 +24,7 @@ export const CreateRtpPage = () => {
   const { mutate, isPending, isError } = useRtps();
   const navigate = useNavigate();
 
-  const onSubmit = (data: CreateRtp) => {
+  const onSubmit = (data: CreateRtp, version: string) => {
     const formattedData: CreateRtp = {
       ...data,
       paymentNotice: {
@@ -33,7 +33,7 @@ export const CreateRtpPage = () => {
       },
     };
 
-    mutate(formattedData, {
+    mutate({ data: formattedData, version }, {
       onSuccess: (response: AxiosResponse) => {
         const location = response.headers['location'];
         const rtpId = getRtpIdFromLocationHeader(location);
@@ -90,23 +90,38 @@ export const CreateRtpPage = () => {
             {t("CreateRtpPage.error")}
           </Alert>
         )}
-        <LoadingButton
-          type="submit"
-          variant="contained"
-          color="primary"
-          disabled={isPending}
-          loading={isPending}
-          sx={{
-            alignSelf: md ? "flex-end" : "center",
-            height: "100%",
-            display: "inline-block",
-            width: md ? "auto" : "fit-content",
-            minHeight: "50px"
-          }}
-          onClick={handleSubmit(onSubmit)}
-        >
-          {t("CreateRtpPage.submitButton")}
-        </LoadingButton>
+        <Stack direction={md ? "column" : "row"} gap={2} sx={{ width: md ? "100%" : "auto" }}>
+          <LoadingButton
+            type="button"
+            variant="outlined"
+            color="primary"
+            disabled={isPending}
+            loading={isPending}
+            sx={{
+              height: "100%",
+              minHeight: "50px",
+              width: md ? "100%" : "auto"
+            }}
+            onClick={handleSubmit((data) => onSubmit(data, "v1"))}
+          >
+            {t("CreateRtpPage.submitButtonV3")}
+          </LoadingButton>
+          <LoadingButton
+            type="button"
+            variant="contained"
+            color="primary"
+            disabled={isPending}
+            loading={isPending}
+            sx={{
+              height: "100%",
+              minHeight: "50px",
+              width: md ? "100%" : "auto"
+            }}
+            onClick={handleSubmit((data) => onSubmit(data, "v2"))}
+          >
+            {t("CreateRtpPage.submitButtonV4")}
+          </LoadingButton>
+        </Stack>
       </Stack>
     </Stack>
   );

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -38,7 +38,8 @@
 		"expiryDateLabel": "Data di scadenza",
 		"subjectLabel": "Oggetto del pagamento",
 		"descriptionLabel": "Descrizione del pagamento",
-		"submitButton": "Crea richiesta",
+		"submitButtonV3": "Invia RTP v3.2",
+		"submitButtonV4": "Invia RTP v4.0",
 		"rtpCreatedSuccess": "RTP creata con successo!",
 		"rtpCreationFailed": "Creazione RTP fallita",
 		"textHelper": {

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -124,8 +124,10 @@
 			"title": "La richiesta è stata inviata con successo!",
 			"body": "Conserva l’id della richiesta, ti servirà in caso di assistenza",
 			"deleteButton": "Cancella richiesta",
-			"cancelModtButton": "Cancella MODT",
-			"cancelPaidButton": "Cancella PAID",
+			"cancelModtButtonV3": "Cancella MODT v3.2",
+			"cancelModtButtonV4": "Cancella MODT v4.0",
+			"cancelPaidButtonV3": "Cancella PAID v3.2",
+			"cancelPaidButtonV4": "Cancella PAID v4.0",
 			"button": "Crea nuova richiesta"
 		},
 		"deleted": {

--- a/src/utils/dialog.utils.tsx
+++ b/src/utils/dialog.utils.tsx
@@ -12,12 +12,12 @@ export type DialogData = {
   content: ReactNode;
 };
 
-export function getDialogData(dialogType: string, rtpId?: string, reason?: CancelReason): DialogData {
+export function getDialogData(dialogType: string, rtpId?: string, reason?: CancelReason, version?: string): DialogData {
   switch (dialogType) {
   case DialogType.DELETE:
     return {
       title: i18next.t('Dialogs.delete.title'),
-      content: <DialogRtpDelete rtpId={rtpId!} reason={reason!} />,
+      content: <DialogRtpDelete rtpId={rtpId!} reason={reason!} version={version!} />,
     };
   default:
     throw new Error(`Tipo di dialogo non supportato: ${dialogType}`);

--- a/src/utils/utilsTest/dialogUtils.test.ts
+++ b/src/utils/utilsTest/dialogUtils.test.ts
@@ -15,11 +15,12 @@ describe('getDialogData', () => {
   it('should return correct data for DELETE dialog type', () => {
     const rtpId = '123';
     const reason = CancelReason.MODT;
-    const result = getDialogData(DialogType.DELETE, rtpId, reason);
+    const version = 'v1';
+    const result = getDialogData(DialogType.DELETE, rtpId, reason, version);
 
     expect(result.title).toBe('Eliminazione in corso...');
     
-    const expectedProps: DialogRtpDeleteProps = { rtpId, reason };
+    const expectedProps: DialogRtpDeleteProps = { rtpId, reason, version };
     expect(result.content).toEqual(React.createElement(DialogRtpDelete, expectedProps));
   });
 


### PR DESCRIPTION
#### Description

This PR introduces support for multiple API versions when submitting and cancelling an RTP. Previously, the application hardcoded the API `version: "v1"` header for these operations. Now, the user interface provides distinct buttons to explicitly select which version of the API should be targeted (v3.2 mapped to `v1`, and v4.0 mapped to `v2`).

#### List of Changes

- **API Hooks**: Updated `useRtps` and `useCancelRtp` to accept an optional `version` parameter. The value is dynamically injected into the `version` request header (defaulting to `"v1"` if not provided).
- **Create RTP Flow**: Replaced the single "Crea richiesta" submit button in `CreateRtpPage` with two new buttons: "Invia RTP v3.2" (uses `v1`) and "Invia RTP v4.0" (uses `v2`).
- **Cancel RTP Flow**: Replaced the previous single cancellation buttons with version-specific variants for both MODT and PAID reasons:
  - Cancella MODT v3.2 / Cancella MODT v4.0
  - Cancella PAID v3.2 / Cancella PAID v4.0
- **Dialog Updates**: Updated `ResultLayout`, `DialogRtpDelete`, and `getDialogData` to propagate the selected API version down to the mutation logic.
- **Translations**: Added new localization keys for the updated versioned buttons.
- **Tests**: Fixed `dialogUtils.test.ts` to accommodate the newly required `version` property in `DialogRtpDeleteProps`.

#### Motivation and Context

The underlying RTP API now supports a `v2` version header (alongside the original `v1`). To allow users to interact with both API versions from the same web application, the UI needs to expose these options explicitly during RTP creation and cancellation actions. 

#### How Has This Been Tested?

- Tested locally by running the development server and verifying the presence of the new buttons on the Create and Success pages.
- Verified that form validation acts correctly before submission.
- [x] Unit Test Suite (Fixed failing unit tests due to updated prop requirements).
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
