### PR TITLE
fix: [SRTP-2043] Fix OK cancellation message

### DIFF
--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -131,7 +131,7 @@
 			"button": "Crea nuova richiesta"
 		},
 		"deleted": {
-			"title": "La richiesta è stata cancellata ",
+			"title": "La richiesta di cancellazione è stata inviata con successo ",
 			"body": "",
 			"button": "Crea nuova richiesta",
 			"deleteButton": ""


### PR DESCRIPTION
#### Description
Cancellation-flow success message wrongly said the RTP was already deleted ("La richiesta è stata cancellata"), when actually the cancellation *request* is the one that is submitted. Fixes the copy to reflect actual state.

#### List of Changes
- Update `it` translation key `deleted.title`: "La richiesta è stata cancellata" → "La richiesta di cancellazione è stata inviata con successo".

#### Motivation and Context
Message misled users into thinking the RTP was already deleted right after submitting a cancellation, even when the cancellation is only pending.

#### How Has This Been Tested?
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Load Tests

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore change (non-breaking change which doesn't provide a direct value to users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.